### PR TITLE
process.on("exit") memory leak

### DIFF
--- a/index.js
+++ b/index.js
@@ -350,7 +350,10 @@ SSDP.prototype.server = function (ip, portno) {
  * Advertise shutdown and close UDP socket.
  */
 SSDP.prototype.stop = function () {
-  process.removeListener('exit', this._stopWrapper);
+  if (this._stopWrapper){
+    process.removeListener('exit', this._stopWrapper);
+    delete this._stopWrapper;
+  }
 
   this.advertise(false)
   this.advertise(false)


### PR DESCRIPTION
Hello,

I have to close and restart SSDP several times !

So the process.on("exit", func) retains a reference to the THIS object.
So I have added process.removeListener() !

Regards,
Olivier
