### PR TITLE
Drop dgram membership on stop()

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -80,6 +80,7 @@ SSDP.prototype.stop = function () {
     return;
   }
 
+  this.sock.dropMembership(this._ssdpIp)
   this.sock.close()
   this.sock = null
 


### PR DESCRIPTION
Fixes EADDRINUSE when attempting to reconnect client after stopping.

I ran into an issue when attempting to use the [node-wemo](https://github.com/hecomi/node-wemo) library, after we are finished with the client and call stop() the dgram binding isn't released. Next time the SSDP client is initialized it attempts to addMembership and fails because the binding is still there. Adding dropMembership to the stop() call will fix the issue.

Unfortunately the recent refactor broke the upstream node-wemo library, I've updated the library in my fork and will pull-request it upstream soon. https://github.com/2fast2fourier/node-wemo
