### PR TITLE
Some fixes

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -48,7 +48,7 @@ SsdpClient.prototype.search = function search(serviceType) {
       'MAN': '"ssdp:discover"',
       'MX': 3
     }
-  ) + "\r\n\r\n"
+  )
 
   self._logger.trace('Sending an M-SEARCH request')
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -328,6 +328,8 @@ SSDP.prototype._getSSDPHeader = function (method, headers, isResponse) {
     message.push(header + ': ' + headers[header])
   })
 
+  message.push('\r\n')
+
   return message.join('\r\n')
 }
 


### PR DESCRIPTION
Hello,
follows a small list of fixes that could be valuable for the module
- in `client.search` HOST is set to multicast
- HTTP headers has to have an additional linebreak
- the `_send` callback was not triggered if called with two arguments

Thank you!
Regards
Luca
