### PR TITLE
Bind ssdp client to a free port selected by the OS.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -22,7 +22,7 @@ util.inherits(SsdpClient, SSDP)
  * @param [cb]
  */
 SsdpClient.prototype.start = function (cb) {
-  this._start(this._ssdpPort, this._unicastHost, cb)
+  this._start(0, this._unicastHost, cb)
 }
 
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "device",
     "upnp"
   ],
-  "version": "2.2.0",
+  "version": "2.2.1",
   "author": "Ilya Shaisultanov <ilya.shaisultanov@gmail.com>",
   "dependencies": {
     "ip": "^0.3.2"


### PR DESCRIPTION
It allows node-ssdp to work on hosts which already run processes bound to port 1900,
for exaple Windows has a default SSDP client bound to port 1900.

Specifying port 0 allows the OS to select a free port, see http://stackoverflow.com/a/1077305.

It should fix https://github.com/diversario/node-ssdp/issues/28 and https://github.com/diversario/node-ssdp/issues/25