### PR TITLE
Accept * wildcards in M-SEARCH packet serviceTypes

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -24,6 +24,7 @@ var httpHeader = /HTTP\/\d{1}\.\d{1} \d+ .*/
  * @param {Number} opts.ttl Packet TTL
  * @param {Boolean} opts.log Disable/enable logging
  * @param {String} opts.logLevel Log level
+ * @param {Boolean} opts.allowWildcards Allow wildcards in M-SEARCH packets (non-standard)
  *
  * @returns {SSDP}
  * @constructor
@@ -92,6 +93,8 @@ SSDP.prototype._init = function (opts) {
 
   this._usns = {}
   this._udn = opts.udn || 'uuid:f40c2981-7329-40b7-8b04-27f187aecfb5'
+
+  this._allowWildcards = opts.allowWildcards
 }
 
 
@@ -275,20 +278,37 @@ SSDP.prototype._respondToSearch = function (serviceType, rinfo) {
   var self = this
     , peer = rinfo.address
     , port = rinfo.port
+    , stRegex
+    , acceptor
 
   // unwrap quoted string
   if (serviceType[0] == '"' && serviceType[serviceType.length-1] == '"') {
     serviceType = serviceType.slice(1, -1)
   }
 
+  if (self._allowWildcards) {
+      stRegex = new RegExp(serviceType.replace(/\*/g, '.*') + '$');
+      acceptor = function(usn, serviceType) {
+          return serviceType === 'ssdp:all' || stRegex.test(usn);
+      }
+  } else {
+      acceptor = function(usn, serviceType) {
+          return serviceType === 'ssdp:all' || usn === serviceType;
+      }
+  }
+
   Object.keys(self._usns).forEach(function (usn) {
     var udn = self._usns[usn]
 
-    if (serviceType === 'ssdp:all' || usn === serviceType) {
+    if (self._allowWildcards) {
+        udn = udn.replace(stRegex, serviceType);
+    }
+
+    if (acceptor(usn, serviceType)) {
       var pkt = self._getSSDPHeader(
         '200 OK',
         {
-          'ST': usn,
+          'ST': serviceType === 'ssdp:all' ? usn : serviceType,
           'USN': udn,
           'LOCATION': self._location,
           'CACHE-CONTROL': 'max-age=' + self._ttl,


### PR DESCRIPTION
Doesn't seem to be standardized anywhere, but Amazon Echo, for
example, searches for WeMo devices using `usn:Belkin:device:**`
and apparently expects that this same usn is returned in both
the ST and USN fields (this is what my physical WeMo device does)