### PR TITLE
Added reuseAddr when dgram socket is created. Reason: If there is onl…

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -106,7 +106,7 @@ SSDP.prototype._init = function (opts) {
  * @private
  */
 SSDP.prototype._createSocket = function () {
-  return dgram.createSocket('udp4')
+  return dgram.createSocket({type: 'udp4', reuseAddr: true})
 }
 
 


### PR DESCRIPTION
…y one SSDP listener running on a system, there is no issue. If there are multiple SSDP related services are running at the same syst em, then the multicast packets are not shared between instances. Only if reuseAddr is set true when socket is created, SSDP multicast messages are shared between different instances. Problem happens if, e.g. a UPnP Server is started after a node-ssdp instance.