### PR TITLE
Remove false advertising

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -45,14 +45,6 @@ SsdpServer.prototype._initAdLoop = function () {
 
   self._logger.info('UDP socket bound', {host: this._unicastHost, port: self._ssdpPort})
 
-  // FIXME: what's the point in advertising we're dead
-  // if the cache is going to be busted anyway?
-  self.advertise(false)
-
-  setTimeout(function () {
-    self.advertise(false)
-  }, 1000)
-
   // Wake up.
   setTimeout(self.advertise.bind(self), 3000)
 


### PR DESCRIPTION
Near as we can tell these lines cause the device to advertise itself as dead over and over from the minute it calls start. Removing these lines appear to fix the issue.