### PR TITLE
Fix nodejs 4.x and 5.x createSocket() compatibility

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -124,9 +124,10 @@ SSDP.prototype._init = function (opts) {
  * @private
  */
 SSDP.prototype._createSocket = function () {
-  if (/^v0\.1[2-8]\.\d+/.test(process.version)) {
+  if (parseFloat(process.version.replace(/\w/, ''))>=0.12) {
     return dgram.createSocket({type: 'udp4', reuseAddr: true})
   }
+
 
   return dgram.createSocket('udp4')
 }


### PR DESCRIPTION
Test nodeJS version, not the package version ! 
(It works better for me)