### PR TITLE
Return on empty NTS header

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -252,7 +252,10 @@ SSDP.prototype._parseCommand = function parseCommand(msg, rinfo) {
  * @param _rinfo
  */
 SSDP.prototype._notify = function (headers, _msg, _rinfo) {
-  if (!headers.NTS) this._logger.trace(headers, 'Missing NTS header')
+  if (!headers.NTS) {
+    this._logger.trace(headers, 'Missing NTS header')
+    return
+  }
 
   switch (headers.NTS.toLowerCase()) {
     // Device coming to life.


### PR DESCRIPTION
This prevents throwing an exception when doing headers.NTS.toLowerCase()