### PR TITLE
Catch an empty NTS header

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -254,7 +254,7 @@ SSDP.prototype._parseCommand = function parseCommand(msg, rinfo) {
 SSDP.prototype._notify = function (headers, _msg, _rinfo) {
   if (!headers.NTS) this._logger.trace(headers, 'Missing NTS header')
 
-  switch (headers.NTS.toLowerCase()) {
+  switch ((headers.NTS || '').toLowerCase()) {
     // Device coming to life.
     case 'ssdp:alive':
       this.emit('advertise-alive', headers)


### PR DESCRIPTION
This prevents throwing an exception when doing headers.NTS.toLowerCase()

This will resolve to the 'default:' case, and still allow logging of the
_msg and _rinfo