### PR TITLE
Fix starting after stop has been called.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -26,6 +26,9 @@ SsdpClient.prototype.start = function (cb) {
   this._start(0, this._unicastHost, cb)
 }
 
+SsdpClient.prototype.stop = function (cb) {
+  this._stop(cb);
+}
 
 /**
  *

--- a/lib/index.js
+++ b/lib/index.js
@@ -136,9 +136,10 @@ SSDP.prototype._createSocket = function () {
 /**
  * Advertise shutdown and close UDP socket.
  */
-SSDP.prototype._stop = function () {
+SSDP.prototype._stop = function (cb) {
   if (!this.sock) {
     this._logger.warn('Already stopped.')
+    cb && cb();
     return
   }
 
@@ -146,6 +147,7 @@ SSDP.prototype._stop = function () {
   this.sock = null
 
   this._socketBound = this._started = false
+  cb && cb();
 }
 
 
@@ -158,7 +160,12 @@ SSDP.prototype._start = function (port, host, cb) {
 
   if (self._started) {
     self._logger.warn('Already started.')
+    cb && cb();
     return
+  }
+
+  if (this.sock === null) {
+    this.sock = this._createSocket();
   }
 
   self._started = true
@@ -193,7 +200,9 @@ SSDP.prototype._start = function (port, host, cb) {
     }
   })
 
-  this.sock.bind(port, host, cb)
+  this.sock.bind(port, host, function () {
+    cb && cb();
+  });
 }
 
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -16,7 +16,7 @@ util.inherits(SsdpServer, SSDP)
  *
  * @param ipAddress
  */
-SsdpServer.prototype.start = function () {
+SsdpServer.prototype.start = function (ipAddress, cb) {
   var self = this
 
   if (self._socketBound) {
@@ -28,9 +28,18 @@ SsdpServer.prototype.start = function () {
 
   this._usns[this._udn] = this._udn
 
-  this._logger.trace('Will try to bind to ' + this._unicastHost + ':' + this._ssdpPort)
+  if (typeof ipAddress === 'function') {
+    cb = ipAddress;
+    ipAddress = null;
+  }
+  var host = ipAddress || this._unicastHost;
 
-  self._start(this._ssdpPort, this._unicastHost, this._initAdLoop.bind(this))
+  this._logger.trace('Will try to bind to ' + host + ':' + this._ssdpPort)
+
+  self._start(this._ssdpPort, this._unicastHost, function () {
+    self._initAdLoop();
+    cb && cb();
+  });
 }
 
 
@@ -45,9 +54,6 @@ SsdpServer.prototype._initAdLoop = function () {
 
   self._logger.info('UDP socket bound', {host: this._unicastHost, port: self._ssdpPort})
 
-  // Wake up.
-  setTimeout(self.advertise.bind(self), 3000)
-
   self._startAdLoop()
 }
 
@@ -57,18 +63,18 @@ SsdpServer.prototype._initAdLoop = function () {
 /**
  * Advertise shutdown and close UDP socket.
  */
-SsdpServer.prototype.stop = function () {
+SsdpServer.prototype.stop = function (cb) {
   if (!this.sock) {
     this._logger.warn('Already stopped.')
+    cb && cb();
     return
   }
 
   this.advertise(false)
-  this.advertise(false)
 
   this._stopAdLoop()
 
-  this._stop()
+  this._stop(cb)
 }
 
 
@@ -76,6 +82,8 @@ SsdpServer.prototype.stop = function () {
 SsdpServer.prototype._startAdLoop = function () {
   assert.equal(this._adLoopInterval, null, 'Attempting to start a parallel ad loop')
 
+  // Run the first iteration immediately
+  this.advertise();
   this._adLoopInterval = setInterval(this.advertise.bind(this), this._adInterval)
 }
 
@@ -117,7 +125,7 @@ SsdpServer.prototype.advertise = function (alive) {
       heads['SERVER'] = self._ssdpSig // why not include this?
     }
 
-    self._logger.trace('Sending an advertisement event')
+    self._logger.trace('Sending ' + nts + ' advertisement')
 
     var message = self._getSSDPHeader('NOTIFY', heads)
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "device",
     "upnp"
   ],
-  "version": "2.6.5",
+  "version": "2.7.0",
   "author": "Ilya Shaisultanov <ilya.shaisultanov@gmail.com>",
   "dependencies": {
     "ip": "^1.0.1"


### PR DESCRIPTION
Previously, when the server was stopped, a null value was assigned to the
variable holding the socket. However, a new socket wasn't created during the
start call (that was done only when creating a server).

After this commit, a new socket is created during starting the server so that
a server can be stopped and started several times without re-creating it.

Added also an optional callback argument to start and stop that can be used
if an application needs to track more exactly when the underlaying async
operations are done.

Fixes #48.
