### PR TITLE
Implemented SsdpClient stop() method

### DIFF
--- a/example/client.js
+++ b/example/client.js
@@ -13,7 +13,12 @@ client.on('response', function inResponse(headers, code, rinfo) {
 
 client.search('urn:schemas-upnp-org:service:ContentDirectory:1')
 
-// Or maybe if you want to scour for everything
-setInterval(function() {
+// Or maybe if you want to scour for everything after 5 seconds
+setTimeout(function() {
   client.search('ssdp:all')
+}, 5000)
+
+// And after 10 seconds, you want to stop
+setTimeout(function () {
+  client.stop()
 }, 10000)

--- a/lib/client.js
+++ b/lib/client.js
@@ -28,6 +28,19 @@ SsdpClient.prototype.start = function (cb) {
 
 
 /**
+ *Close UDP socket.
+ */
+SsdpClient.prototype.stop = function () {
+  if (!this.sock) {
+    this._logger('Already stopped.')
+    return
+  }
+
+  this._stop()
+}
+
+
+/**
  *
  * @param {String} serviceType
  * @returns {*}

--- a/lib/index.js
+++ b/lib/index.js
@@ -54,6 +54,7 @@ function SSDP(opts, sock) {
     this.sock = sock
   } else {
     this.sock = this._createSocket()
+    this.sock.unref()
   }
 
   EE.call(self)


### PR DESCRIPTION
Fixes #54 . Added a this.sock.unref() in the constructor phase. 

From: https://nodejs.org/api/dgram.html#dgram_socket_unref 

> By default, binding a socket will cause it to block the Node.js process from exiting as long as the socket is open. The socket.unref() method can be used to exclude the socket from the reference counting that keeps the Node.js process active, allowing the process to exit even if the socket is still listening.

The `this.sock.close()` and `this.sock = null` as implemented in `SSDP.prototype._stop()` will still keep node occupied after everything is done. Adding the unref() to the constructor remedies this. The example demonstrates this by cleanly exitting after a setTimeout calls the exposed SsdpClient stop() method.

Happy to discuss and rework based on your comments as needed.