### PR TITLE
Handle EADDRNOTAVAIL error

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -175,7 +175,7 @@ SSDP.prototype._start = function (port, host, cb) {
         self.sock.addMembership(self._ssdpIp)
         self.sock.setMulticastTTL(self._ssdpTtl)
       } catch (e) {
-        if (e.code === 'ENODEV') {
+        if (e.code === 'ENODEV' || e.code === 'EADDRNOTAVAIL') {
           self._logger('No interface present to add multicast group membership. Scheduling a retry. %s', e.message)
           setTimeout(addMembership, 5000)
         } else {


### PR DESCRIPTION
EADDRNOTAVAIL happens when there is no network connection on my machine.

You can reliably cause this error by disabling Wi-Fi on OS X.

For https://github.com/feross/webtorrent-desktop/issues/375