### PR TITLE
Allow custom bind port

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ SSDP constructor accepts an optional configuration object and an optional initia
 - `ssdpTtl` _Number_ Multicast TTL. Default: `1`
 - `adInterval` _Number_ `advertise` event frequency (ms). Default: 10 sec.
 - `unicastHost` _String_ IP address or hostname of server where SSDP service is running. This is used in `HOST` header. Default: `0.0.0.0`.
+- `unicostBindPort` _Number_ Port for the SSDP service to bind to. Defaults to 0 which uses a randomly selected available port.
 - `location` _String_ URL pointing to description of your service, or a function which returns that URL
 - `udn` _String_ Unique Device Name. Default: `uuid:f40c2981-7329-40b7-8b04-27f187aecfb5`.
 - `description` _String_ Path to description file. Default: `upnp/desc.php`.

--- a/lib/client.js
+++ b/lib/client.js
@@ -23,7 +23,7 @@ util.inherits(SsdpClient, SSDP)
  * @param [cb]
  */
 SsdpClient.prototype.start = function (cb) {
-  this._start(0, this._unicastHost, cb)
+  this._start(this._unicastBindPort, this._unicastHost, cb)
 }
 
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -96,6 +96,7 @@ SSDP.prototype._init = function (opts) {
   }
 
   this._unicastHost = opts.unicastHost || '0.0.0.0'
+  this._unicastBindPort = opts.unicastBindPort || 0
   this._ssdpServerHost = this._ssdpIp + ':' + this._ssdpPort
 
   this._usns = {}


### PR DESCRIPTION
Hello

This allows a custom Bind port to be specified. I needed it so I could use this with an app on a server with a firewall so all the listener ports needed to be fixed.

Thanks!