### PR TITLE
Added address information to advertise-alive events

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -243,10 +243,10 @@ SSDP.prototype._parseCommand = function parseCommand(msg, rinfo) {
  * Emits `advertise-alive`, `advertise-bye` events.
  *
  * @param headers
- * @param _msg
- * @param _rinfo
+ * @param msg
+ * @param rinfo
  */
-SSDP.prototype._notify = function (headers, _msg, _rinfo) {
+SSDP.prototype._notify = function (headers, msg, rinfo) {
   if (!headers.NTS) {
     this._logger('Missing NTS header: %o', headers)
     return
@@ -255,16 +255,16 @@ SSDP.prototype._notify = function (headers, _msg, _rinfo) {
   switch (headers.NTS.toLowerCase()) {
     // Device coming to life.
     case 'ssdp:alive':
-      this.emit('advertise-alive', headers)
+      this.emit('advertise-alive', headers, rinfo)
       break
 
     // Device shutting down.
     case 'ssdp:byebye':
-      this.emit('advertise-bye', headers)
+      this.emit('advertise-bye', headers, rinfo)
       break
 
     default:
-      this._logger('Unhandled NOTIFY event: %o', {'message': _msg, 'rinfo': _rinfo})
+      this._logger('Unhandled NOTIFY event: %o', {'message': msg, 'rinfo': rinfo})
   }
 }
 


### PR DESCRIPTION
The commit adds address information to advertise-alive events when SSDP NOTIFY msgs are received. This is especially useful for older SSDP devices. I also made some inconsequential changes to variable names just to match the other code better.