### PR TITLE
Add optional additional ssdp headers

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -119,6 +119,8 @@ SSDP.prototype._init = function (opts) {
   this._udn = opts.udn || 'uuid:f40c2981-7329-40b7-8b04-27f187aecfb5'
 
   this._allowWildcards = opts.allowWildcards
+
+  this._additionalHeaders = opts.additionalHeaders || {}
 }
 
 
@@ -378,18 +380,17 @@ SSDP.prototype._respondToSearch = function (serviceType, rinfo) {
     }
 
     if (acceptor(usn, serviceType)) {
-      var pkt = self._getSSDPHeader(
-        '200 OK', {
-          'ST': serviceType === c.SSDP_ALL ? usn : serviceType,
-          'USN': udn,
-          'LOCATION': self._location,
-          'CACHE-CONTROL': 'max-age=' + self._ttl,
-          'DATE': new Date().toUTCString(),
-          'SERVER': self._ssdpSig,
-          'EXT': ''
-        },
-        true
-      )
+      var heads = {
+        'ST': serviceType === c.SSDP_ALL ? usn : serviceType,
+        'USN': udn,
+        'LOCATION': self._location,
+        'CACHE-CONTROL': 'max-age=' + self._ttl,
+        'DATE': new Date().toUTCString(),
+        'SERVER': self._ssdpSig,
+        'EXT': ''
+      };
+      heads = Object.assign(heads, self._additionalHeaders)
+      var pkt = self._getSSDPHeader('200 OK', heads, true)
 
       self._logger('Sending a 200 OK for an M-SEARCH: %o', {'peer': peer_addr, 'port': peer_port})
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -134,6 +134,8 @@ SsdpServer.prototype.advertise = function (alive) {
       'USN': udn
     }
 
+    heads = Object.assign(heads, self._additionalHeaders);
+
     if (alive) {
       heads.LOCATION = self._location
       heads['CACHE-CONTROL'] = 'max-age=1800'

--- a/test/lib/server.js
+++ b/test/lib/server.js
@@ -152,7 +152,11 @@ describe('Server', function () {
         ssdpSig: 'signature',
         ttl: 'ttl',
         description: 'desc',
-        udn: 'device name'
+        udn: 'device name',
+        additionalHeaders: {
+          HEADER1: 'header1',
+          HEADER2: 'header2'
+        }
       })
 
       var iface = Object.keys(server.sockets)[0]
@@ -189,6 +193,8 @@ describe('Server', function () {
       assert.equal(headers1.LOCATION, 'location header')
       assert.equal(headers1['CACHE-CONTROL'], 'max-age=1800')
       assert.equal(headers1.SERVER, 'signature')
+      assert.equal(headers1.HEADER1, 'header1')
+      assert.equal(headers1.HEADER2, 'header2')
 
       var port1 = args1[3]
       assert.equal(port1, 1900)


### PR DESCRIPTION
UPnP allows the use of additional SSDP headers if correctly
namespaced. Provide this functionality.