### PR TITLE
Option for explicit interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ SSDP constructor accepts an optional configuration object and an optional initia
 - `ttl` _Number_ Packet TTL. Default: `1800`.
 - `allowWildcards` _Boolean_ Accept wildcards (`*`) in `serviceTypes` of `M-SEARCH` packets, e.g. `usn:Belkin:device:**`. Default: `false`
 - `explicitSocketBind` _Boolean_ Bind sockets to each discovered interface explicitly instead of relying on the system. Might help with issues with multiple NICs.
+- `interfaces` _String[]_ List of interfaces to explicitly bind.
 - `customLogger` _Function_ A logger function to use instead of the default. The first argument to the function can contain a format string.
 - `reuseAddr` _Boolean_ When true `socket.bind()` will reuse the address, even if another process has already bound a socket on it. Default: `true`
 - `suppressRootDeviceAdvertisements` _Boolean_ When true the SSDP server will not advertise the root device (i.e. the bare UDN). In some scenarios this advertisement is not needed. Default: `false`

--- a/lib/index.js
+++ b/lib/index.js
@@ -95,6 +95,7 @@ SSDP.prototype._init = function (opts) {
   this._ssdpSig = opts.ssdpSig || getSsdpSignature()
 
   this._explicitSocketBind = opts.explicitSocketBind
+  this._interfaces = opts.interfaces
   this._reuseAddr = opts.reuseAddr === undefined ? true : opts.reuseAddr
 
   // User shouldn't need to set these
@@ -153,24 +154,26 @@ SSDP.prototype._createSockets = function () {
   Object.keys(interfaces).forEach(function (iName) {
     self._logger('discovering all IPs from interface %s', iName)
 
-    interfaces[iName].forEach(function (ipInfo) {
-      if (ipInfo.internal == false && ipInfo.family == "IPv4") {
-        self._logger('Will use interface %s', iName)
-        var socket
+    if (!self._interfaces || self._interfaces.indexOf(iName) > -1) {
+        interfaces[iName].forEach(function (ipInfo) {
+          if (ipInfo.internal == false && ipInfo.family == "IPv4") {
+            self._logger('Will use interface %s', iName)
+            var socket
 
-        if (parseFloat(process.version.replace(/\w/, '')) >= 0.12) {
-          socket = dgram.createSocket({type: 'udp4', reuseAddr: self._reuseAddr})
-        } else {
-          socket = dgram.createSocket('udp4')
-        }
+            if (parseFloat(process.version.replace(/\w/, '')) >= 0.12) {
+              socket = dgram.createSocket({type: 'udp4', reuseAddr: self._reuseAddr})
+            } else {
+              socket = dgram.createSocket('udp4')
+            }
 
-        if (socket) {
-          socket.unref()
+            if (socket) {
+              socket.unref()
 
-          self.sockets[ipInfo.address] = socket
-        }  
-      }
-    })
+              self.sockets[ipInfo.address] = socket
+            }
+          }
+        })
+    }
   })
 }
 


### PR DESCRIPTION
Working with devices with multiple NICs, I need to restrict the Client to only using a specific interface (a LAN interface in this case).  

An option to explicitly list the interfaces like this would be nice:
`new Client({ explicitSocketBind: true, interfaces: ['eth4']})`

Currently, if I just use explicitSocketBind, it will correctly use the LAN interface, but will send N times the number of searches on the LAN (once for every interface).